### PR TITLE
Add profiling scripts

### DIFF
--- a/dev/resources/root-templates/typed/clj.checker/deps.edn
+++ b/dev/resources/root-templates/typed/clj.checker/deps.edn
@@ -46,7 +46,7 @@
     org.clojure/tools.nrepl
     {:mvn/version "{◊tools-nrepl-mvn-version◊}", :exclusions [org.clojure/clojure]}
     com.clojure-goes-fast/clj-java-decompiler {:mvn/version "0.3.0"}
-    com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.2.2"}
+    com.clojure-goes-fast/clj-async-profiler {:mvn/version "{◊clj-async-profiler-mvn-version◊}"}
     ;; for shared tests
     {◊typedclojure-group-id◊}/typed.cljs.checker {:local/root "../cljs.checker" :deps/manifest :deps}
     ;; optional typed.lib.clojure dep
@@ -59,6 +59,10 @@
   {:extra-deps {codox/codox {:mvn/version "{◊codox-mvn-version◊}"}}
    :extra-paths ["script"]
    :main-opts ["-m" "gen-doc"]}
+  :profile
+  {:extra-deps {com.clojure-goes-fast/clj-async-profiler {:mvn/version "{◊clj-async-profiler-mvn-version◊}"}}
+   :extra-paths ["script"]
+   :main-opts ["-m" "profile"]}
   :eastwood
   {:main-opts ["-m" "eastwood.lint" {}]
    :extra-deps {jonase/eastwood {:mvn/version "0.9.4"}}}

--- a/dev/src/typed/dev/helpers.clj
+++ b/dev/src/typed/dev/helpers.clj
@@ -56,4 +56,5 @@
    :beholder-mvn-version "1.0.2"
    :process-mvn-version "0.5.21"
    :fully-satisfies-mvn-version "1.12.0"
+   :clj-async-profiler-mvn-version "1.2.2"
    })

--- a/script/profile-all
+++ b/script/profile-all
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+cd typed/clj.checker
+./script/profile 10 cpu
+./script/profile 10 alloc

--- a/typed/clj.checker/deps.edn
+++ b/typed/clj.checker/deps.edn
@@ -59,6 +59,10 @@
   {:extra-deps {codox/codox {:mvn/version "0.10.7"}}
    :extra-paths ["script"]
    :main-opts ["-m" "gen-doc"]}
+  :profile
+  {:extra-deps {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.2.0"}}
+   :extra-paths ["script"]
+   :main-opts ["-m" "profile"]}
   :eastwood
   {:main-opts ["-m" "eastwood.lint" {}]
    :extra-deps {jonase/eastwood {:mvn/version "0.9.4"}}}

--- a/typed/clj.checker/deps.edn
+++ b/typed/clj.checker/deps.edn
@@ -60,7 +60,7 @@
    :extra-paths ["script"]
    :main-opts ["-m" "gen-doc"]}
   :profile
-  {:extra-deps {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.2.0"}}
+  {:extra-deps {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.2.2"}}
    :extra-paths ["script"]
    :main-opts ["-m" "profile"]}
   :eastwood

--- a/typed/clj.checker/script/profile
+++ b/typed/clj.checker/script/profile
@@ -3,7 +3,7 @@
 # ./script/profile 10 cpu
 # ./script/profile 10 alloc
 #
-# Then view the reuslts in file:///tmp/clj-async-profiler/results/
+# Then view the results in file:///tmp/clj-async-profiler/results/
 
 set -x
 

--- a/typed/clj.checker/script/profile
+++ b/typed/clj.checker/script/profile
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# ./script/profile 10 cpu
+# ./script/profile 10 alloc
+#
+# Then view the reuslts in file:///tmp/clj-async-profiler/results/
+
+set -x
+
+clojure -M:test:profile "$@"

--- a/typed/clj.checker/script/profile.clj
+++ b/typed/clj.checker/script/profile.clj
@@ -1,0 +1,60 @@
+(ns profile
+  (:require [clj-async-profiler.core :as prof]
+            [clojure.core.typed.test.self-check-tc :as self-check]))
+
+(defn run-self-check-for [seconds]
+  (let [deadline (+ (System/currentTimeMillis) (* 1000 seconds))]
+    (while (< (System/currentTimeMillis) deadline)
+      (with-out-str (self-check/check-tc)))))
+
+(def transforms
+  [;; Hide JIT compialtion from profile
+   {:type :remove
+    :what ";CompileBroker::compiler_thread_loop;"}
+   ;; Collapse recursive check-expr
+   {:type :replace
+    :what #";(typed\.clj\.checker\.check/check-expr;).*\1"
+    :replacement ";$1"}
+   ;; Extract read+string into separate tree
+   {:type :replace
+    :what #".+(clojure\.tools\.reader/read\+string;)"
+    :replacement ";$1"}
+   ;; Extract run-pre-passes into separate tree
+   {:type :replace
+    :what #".+(typed\.cljc\.analyzer/run-pre-passes;)"
+    :replacement ";$1"}
+   ;; Extract run-post-passes into separate tree
+   {:type :replace
+    :what #".+(typed\.cljc\.analyzer/run-post-passes;)"
+    :replacement ";$1"}
+   ;; Extract analyze-outer into separate tree
+   {:type :replace
+    :what #".+(typed\.cljc\.analyzer/analyze-outer;)"
+    :replacement ";$1"}
+   ;; Collapse recursive subtypeA*
+   {:type :replace
+    :what #";(typed\.clj\.checker\.subtype/subtypeA\*;).*\1"
+    :replacement ";$1"}
+   ;; Extract subtypeA* into separate tree
+   {:type :replace
+    :what #".+(typed\.clj\.checker\.subtype/subtypeA\*;)"
+    :replacement ";$1"}
+   ;; Collapse recursive RClass-supers*
+   {:type :replace
+    :what #";(typed\.cljc\.checker\.type-ctors/RClass-supers\*;).*\1"
+    :replacement ";$1"}
+   ;; Extract force-type into separate tree
+   {:type :replace
+    :what #".+(typed\.cljc\.runtime\.env-utils/force-type;)"
+    :replacement ";$1"}])
+
+(defn -main [& [duration-in-secs event]]
+  (let [secs (parse-long duration-in-secs)
+        event (keyword event)]
+    (case event
+      (:cpu :alloc)
+      (do (println "Warming up...")
+          (run-self-check-for 10)
+          (prof/profile {:event event, :predefined-transforms transforms}
+            (run-self-check-for secs)))))
+  (shutdown-agents))


### PR DESCRIPTION
The comment in the bash script mentions how to launch it and what is the result. I've added the transforms that I use for self-check profiling most of the time. They mostly collapse the recursive parts and single out the meaningful big "blocks" of the execution (reader, analyzer, subtypeA*, etc.).