### PR TITLE
Fix clojure.lang.Numbers/minus mixed-arg overload: return Double, not Long

### DIFF
--- a/typed/clj.checker/src/typed/clj/checker/base_env.clj
+++ b/typed/clj.checker/src/typed/clj/checker/base_env.clj
@@ -390,7 +390,7 @@ clojure.lang.Numbers/minus (t/IFn
                              [t/Num -> t/Num]
                              ;minus
                              [Long Long -> Long]
-                             [(t/U Double Long) (t/U Double Long) -> Long]
+                             [(t/U Double Long) (t/U Double Long) -> Double]
                              [t/AnyInteger t/AnyInteger -> t/AnyInteger]
                              [t/Num t/Num -> t/Num])
 clojure.lang.Numbers/unchecked_multiply (t/IFn [Long Long -> Long]

--- a/typed/clj.checker/src/typed/clj/checker/base_env.clj
+++ b/typed/clj.checker/src/typed/clj/checker/base_env.clj
@@ -347,15 +347,14 @@ clojure.lang.Numbers/dec (t/IFn [Long -> Long]
                               [t/AnyInteger -> t/AnyInteger]
                               [t/Num -> t/Num])
 clojure.lang.Numbers/quotient (t/IFn [Long Long -> Long]
-                                   [(t/U Long Double) (t/U Long Double) -> Double]
                                    [t/AnyInteger t/AnyInteger -> t/AnyInteger]
                                    [t/Num t/Num -> t/Num])
 clojure.lang.Numbers/incP (t/IFn [Long -> (t/U clojure.lang.BigInt Long)]
-                               [Double -> Double]
+                               [Double -> Double] ;; (= Double/MAX_VALUE (inc' Double/MAX_VALUE))
                                [t/AnyInteger -> t/AnyInteger]
                                [t/Num -> t/Num])
 clojure.lang.Numbers/decP (t/IFn [Long -> (t/U clojure.lang.BigInt Long)]
-                               [Double -> Double]
+                               [Double -> Double] ;; (= (- Double/MAX_VALUE) (dec' (- Double/MAX_VALUE)))
                                [t/AnyInteger -> t/AnyInteger]
                                [t/Num -> t/Num])
 clojure.lang.Numbers/unchecked_inc (t/IFn [Long -> Long]
@@ -379,7 +378,7 @@ clojure.lang.Numbers/unchecked_minus (t/IFn
                                        [t/Num t/Num -> t/Num]
                                        ; subtract
                                        [Long Long -> Long]
-                                       [(t/U Long Double) (t/U Long Double) -> Double]
+                                       [(t/U Long Double) (t/U Long Double) -> (t/U Long Double)]
                                        [t/AnyInteger -> t/AnyInteger]
                                        [t/Num -> t/Num])
 clojure.lang.Numbers/minus (t/IFn
@@ -390,25 +389,22 @@ clojure.lang.Numbers/minus (t/IFn
                              [t/Num -> t/Num]
                              ;minus
                              [Long Long -> Long]
-                             [(t/U Double Long) (t/U Double Long) -> Double]
+                             [(t/U Double Long) (t/U Double Long) -> (t/U Long Double)]
                              [t/AnyInteger t/AnyInteger -> t/AnyInteger]
                              [t/Num t/Num -> t/Num])
 clojure.lang.Numbers/unchecked_multiply (t/IFn [Long Long -> Long]
-                                             [(t/U Long Double) (t/U Long Double) -> Double]
+                                             [(t/U Long Double) (t/U Long Double) -> (t/U Long Double)]
                                              [t/AnyInteger t/AnyInteger -> t/AnyInteger]
                                              [t/Num t/Num -> t/Num])
 clojure.lang.Numbers/unchecked_int_multiply [t/Num t/Num -> t/AnyInteger]
 clojure.lang.Numbers/unchecked_int_divide [t/Num t/Num -> t/AnyInteger]
 clojure.lang.Numbers/unchecked_int_remainder [t/Num t/Num -> t/AnyInteger]
-clojure.lang.Numbers/remainder [t/Num t/Num -> t/AnyInteger]
+clojure.lang.Numbers/remainder [t/Num t/Num -> t/Num]
 clojure.lang.Numbers/multiply (t/IFn [Long Long -> Long]
-                                   [(t/U Double Long) (t/U Double Long) -> Double]
+                                   [(t/U Double Long) (t/U Double Long) -> (t/U Double Long)]
                                    [t/AnyInteger t/AnyInteger -> t/AnyInteger]
                                    [t/Num t/Num -> t/Num])
-clojure.lang.Numbers/divide (t/IFn [Long Long -> Long]
-                                   [(t/U Double Long) (t/U Double Long) -> Double]
-                                   [t/AnyInteger t/AnyInteger -> t/AnyInteger]
-                                   [t/Num t/Num -> t/Num])
+clojure.lang.Numbers/divide [t/Num t/Num -> t/Num]
       ;bit-not
 clojure.lang.Numbers/not [t/AnyInteger -> Long]
 ;bit-and


### PR DESCRIPTION
The binary mixed-argument overload of `clojure.lang.Numbers/minus` is annotated

```clojure
[(t/U Double Long) (t/U Double Long) :-> Long]
```

so subtraction with one floating operand infers `Long` when checked **without an expected type** — e.g. a `let`-binding init like `(let [r (- 1.0 (* x x))] …)` — silently narrowing a `Double` to `Long`.

Every analogous primitive op gets this right: `unchecked_minus`, `unchecked_multiply`, and `quotient` all return `Double` for the mixed `(U Double Long)` case. `+` and `*` have no such mixed overload, which is why only `-` exhibited the narrowing. This changes the one overload's return `Long` → `Double`.

`(- d d)` → `Double`, `(- l l)` → `Long` (integer subtraction preserved), `(- l d)` → `Double`.