### PR TITLE
core/let: expose per-binding types on the checked AST (+ defuspecial implicit-eval fix)

### DIFF
--- a/typed/clj.checker/src/typed/cljc/checker/check/unanalyzed.cljc
+++ b/typed/clj.checker/src/typed/cljc/checker/check/unanalyzed.cljc
@@ -43,8 +43,19 @@
     ;(prn `-unanalyzed-special-dispatch form res)
     res))
 
-(defn run-passes+propagate-expr-type [expr opts]
-  (-> expr
+(defn run-passes+propagate-expr-type [expr orig-expr opts]
+  (-> (cond-> expr
+        ;; A defuspecial rule may hand back an already-analyzed node. That skips
+        ;; the :unanalyzed->analyzed transition where `propagate-top-level` marks
+        ;; top-level forms for Gilardi evaluation, so without this an analyzed
+        ;; top-level result would never be evaluated — violating the documented
+        ;; "implicitly evaluated after control returns" contract (e.g. a rule that
+        ;; returns a checked `(let [v (def f)] ...)` would not define `f`).
+        ;; Re-establish the mark from the original (top-level?) expr.
+        (and (ana2/top-level? orig-expr)
+             (not= :unanalyzed (:op expr))
+             (not (ana2/eval-top-level? expr)))
+        ana2/mark-eval-top-level)
       (ana2/run-passes opts)
       (into (select-keys expr [u/expr-type]))))
 
@@ -112,12 +123,17 @@
         [argv args] (if (vector? (first args))
                       ((juxt first rest) args)
                       [nil args])
-        gopts (gensym 'opts)]
+        gopts (gensym 'opts)
+        gexpr (gensym 'expr)]
     (assert (vector? argv))
     (assert (not-any? #{'&} argv))
     (assert (= 3 (count argv)))
     `(defn ~vsym
        ~@(when doc [doc])
-       ~(-> argv pop (conj gopts))
-       (some-> (let [~(peek argv) ~gopts] ~@args)
-               (run-passes+propagate-expr-type ~gopts)))))
+       [~gexpr ~(nth argv 1) ~gopts]
+       (some-> (let [~(nth argv 0) ~gexpr
+                     ~(nth argv 2) ~gopts]
+                 ~@args)
+               ;; pass the original (pre-rule) expr so the wrapper can recover its
+               ;; top-level status for Gilardi evaluation (see run-passes+…).
+               (run-passes+propagate-expr-type ~gexpr ~gopts)))))

--- a/typed/lib.clojure/src/typed/clj/ext/clojure/core__let.clj
+++ b/typed/lib.clojure/src/typed/clj/ext/clojure/core__let.clj
@@ -342,8 +342,28 @@
               (-> (pad-vector expanded-bindings bvec)
                   (with-meta (meta bvec)))))))
 
+(defn- check-let-via-let*
+  "Check a no-destructuring clojure.core/let by rewriting it to let* and checking
+  normally. Simple-symbol binders are already valid let* binders, so this is a
+  plain let->let* rename. The result is a fully-checked :let AST node, so each
+  binding's type lands on the checked binding AST node (exactly like let*/loop*)
+  and occurrence typing / object propagation go through the standard path —
+  unlike re-emitting a form, where the binding types are lost when run-passes
+  re-analyzes it."
+  [{ana-env :env :keys [form]} expected {::check/keys [check-expr] :as opts}]
+  (let [[_ bvec & body-syns] form]
+    (-> (list* 'let* bvec body-syns)
+        (with-meta (meta form))
+        (ana2/unanalyzed ana-env opts)
+        (check-expr expected opts))))
+
 (defuspecial defuspecial__let
-  "defuspecial implementation for clojure.core/let"
+  "defuspecial implementation for clojure.core/let.
+
+  No destructuring → check via let* so per-binding types land on the checked
+  binding AST nodes (like let*/loop*) and occurrence typing works the standard
+  way. With destructuring → keep the bespoke destructure-aware check, which
+  produces TC's friendly destructuring type errors."
   [{ana-env :env :keys [form] :as expr} expected {::check/keys [check-expr] :as opts}]
   (assert check-expr)
   (let [_ (assert (next form)
@@ -352,31 +372,37 @@
         _ (assert (vector? bvec)
                   (str "Expected binding vector as first argument of clojure.core/let:" (pr-str bvec)))
         _ (assert (even? (count bvec))
-                  (str "Uneven binding vector passed to clojure.core/let: " bvec))
-        {:keys [prop-env ana-env expanded-bindings new-syms reachable]}
-        (check-let-bindings
-          {:new-syms #{}
-           :prop-env (lex/lexical-env opts)
-           :ana-env ana-env}
-          bvec
-          opts)]
-    (cond
-      (not reachable) (assoc expr 
-                             :form (-> (list* (first form)
-                                              expanded-bindings
-                                              body-syns)
-                                       (with-meta (meta form)))
-                             u/expr-type (or expected (r/ret (r/Bottom))))
-      :else (let [cbody (let [body (-> `(do ~@body-syns)
-                                       (ana2/unanalyzed ana-env opts))
-                              opts (var-env/with-lexical-env opts prop-env)]
-                          (let [opts (assoc opts ::vs/current-expr body)]
-                            (-> body
-                                (check-expr expected opts))))
-                  unshadowed-ret (let/erase-objects new-syms (u/expr-type cbody) opts)]
-              (assoc expr
-                     :form (-> (list (first form)
-                                     expanded-bindings
-                                     (emit-form/emit-form cbody opts))
-                               (with-meta (meta form)))
-                     u/expr-type unshadowed-ret)))))
+                  (str "Uneven binding vector passed to clojure.core/let: " bvec))]
+    (if (every? simple-symbol? (take-nth 2 bvec))
+      ;; Check via let* so per-binding types land on the checked binding AST
+      ;; nodes. defuspecial's wrapper re-establishes top-level Gilardi evaluation
+      ;; for this analyzed result, so inner top-level defs (defmulti/defrecord)
+      ;; are still evaluated.
+      (check-let-via-let* expr expected opts)
+      (let [{:keys [prop-env ana-env expanded-bindings new-syms reachable]}
+            (check-let-bindings
+              {:new-syms #{}
+               :prop-env (lex/lexical-env opts)
+               :ana-env ana-env}
+              bvec
+              opts)]
+        (cond
+          (not reachable) (assoc expr
+                                 :form (-> (list* (first form)
+                                                  expanded-bindings
+                                                  body-syns)
+                                           (with-meta (meta form)))
+                                 u/expr-type (or expected (r/ret (r/Bottom))))
+          :else (let [cbody (let [body (-> `(do ~@body-syns)
+                                           (ana2/unanalyzed ana-env opts))
+                                  opts (var-env/with-lexical-env opts prop-env)]
+                              (let [opts (assoc opts ::vs/current-expr body)]
+                                (-> body
+                                    (check-expr expected opts))))
+                      unshadowed-ret (let/erase-objects new-syms (u/expr-type cbody) opts)]
+                  (assoc expr
+                         :form (-> (list (first form)
+                                         expanded-bindings
+                                         (emit-form/emit-form cbody opts))
+                                   (with-meta (meta form)))
+                         u/expr-type unshadowed-ret)))))))

--- a/typed/lib.clojure/test/typed_test/clj/ext/clojure/core__let.clj
+++ b/typed/lib.clojure/test/typed_test/clj/ext/clojure/core__let.clj
@@ -204,3 +204,22 @@
                (let [v (.hasRoot v)]
                  v)
                nil))))
+
+(deftest let-binding-types-on-ast-test
+  ;; Per-binding types are exposed on the checked let AST node's :bindings,
+  ;; like let*/loop* — so tools consuming the AST can read each binding's
+  ;; inferred type (e.g. to drive downstream code generation).
+  (let [etk :typed.cljc.checker.utils/expr-type
+        ast (:checked-ast (t/check-form-info '(let [x 1 y "a"] y) :checked-ast true))
+        acc (atom {})]
+    (letfn [(walk [n]
+              (when (map? n)
+                (when (= :let (:op n))
+                  (doseq [b (:bindings n)]
+                    (when-let [tcr (get b etk)]
+                      (swap! acc assoc (:form b) (:t tcr)))))
+                (doseq [k (:children n)]
+                  (let [v (get n k)] (if (vector? v) (run! walk v) (walk v))))))]
+      (walk ast))
+    (is (contains? @acc 'x) "binding x's type is on the checked AST")
+    (is (contains? @acc 'y) "binding y's type is on the checked AST")))


### PR DESCRIPTION
Supersedes #195 (reworked from scratch — that PR's comments sit on the old `let*`-node / `unchecked-*` / `method.clj` approach).

## Summary

The `clojure.core/let` typing rule re-emitted a form and returned the `:unanalyzed` node, so its per-binding types were lost when `run-passes` re-analyzed the result — consumers can't read each binding's inferred type off the checked AST the way they can for `let*`/`loop*`.

This reworks the no-destructuring case to rewrite `let`→`let*` and check it normally (`check-let-via-let*`), returning a fully-checked `:let` node so each binding's type lands on its binding AST node, exactly like `let*`/`loop*` (`check/let.clj`). Occurrence typing and object propagation go through the standard path. Destructuring keeps the bespoke `check-let-bindings` path for its friendly destructure type-error messages (a raw `nth`-based macroexpansion would raise an internal error instead).

## The `defuspecial` implicit-eval fix

Doing the above surfaced a latent gap. `install-defuspecial` documents that the returned expression "is implicitly evaluated (via `ana2/eval-top-level`) after control is returned to the type checker." That holds for the usual case where a rule returns the original `:unanalyzed` node: `run-passes`' `:unanalyzed`→analyzed transition runs `propagate-top-level`, which marks top-level forms with `::eval-gilardi?` so `eval-top-level` evaluates them.

But a rule that returns an **already-analyzed** node skips that transition, so a top-level analyzed result is never marked and never evaluated — silently violating the contract. Concretely, a rule returning a checked `(let [v (def f)] …)` type-checks fine but fails to define `f` (so e.g. a following `defmethod` can't resolve the multifn).

`run-passes+propagate-expr-type` now re-establishes the mark from the original `expr`'s top-level status when the rule returns an analyzed node. It's gated on `(not= :unanalyzed (:op expr))`, so it's a **no-op for every existing re-emit rule** — only rules that hand back analyzed nodes are affected (currently just `core/let`). The `defuspecial` macro is updated to thread the original `expr` through.

(Kept as a separate commit; happy to split into its own PR if you'd rather review the core-machinery change on its own.)

## Tests

- new `let-binding-types-on-ast-test` (per-binding types are present on the checked `let` AST)
- `typed-test.clj.ext.clojure.core__let`: 44 → 46 pass, 0 fail/err (occurrence typing + destructuring + tags)
- `typed-test.clj.ext.clojure.core`: 248/0/0 (friendly destructure error messages, incl. `defmethod`)
- `clojure.core.typed.test.core`: 984 pass / 2 fail / 0 err (the 2 are pre-existing `loop-errors-test` on main)
- spot-checked green: `…ext.clojure.core__fn`/`__for`/`__doseq`, `check.deftype`, `check.reify`, `multimethods`, and the `protocol`/`records`/`defprotocol` fixtures

## Use case

A downstream JIT compiler reads per-binding types off the checked `let` AST to devirtualize arithmetic, wanting parity with how it already reads `let*`/`loop*`.
