### PR TITLE
core/let: per-binding types on the checked AST (incl. destructuring) + nth & loop fixes

### DIFF
--- a/typed/clj.checker/src/typed/cljc/checker/check/let.clj
+++ b/typed/clj.checker/src/typed/cljc/checker/check/let.clj
@@ -81,6 +81,23 @@
           ret
           syms))
 
+(defn widen-loop-binding-init
+  "Type for an unannotated loop binding, inferred from its init expression.
+
+  A singleton Value type (e.g. (Val 0) from the literal 0) is too narrow to be a
+  loop invariant: the binding must hold for every iteration, but recur passes a
+  value that differs from the init (e.g. (recur (inc i)) passes (Val 1)). Widen a
+  Value type to the concrete class of its value (Long for 0, Double for 0.0, ...)
+  so the common accumulator loop checks while keeping the primitive class — which
+  consumers reading per-binding types off the AST rely on. Non-Value types are
+  already general enough (or the user can annotate)."
+  [t opts]
+  {:pre [(r/Type? t)]
+   :post [(r/Type? %)]}
+  (if (and (r/Value? t) (some? (:val t)))
+    (c/RClass-of (class (:val t)) opts)
+    t))
+
 (defn check-let
   ([expr expected opts] (check-let expr expected {} opts))
   ([{:keys [body bindings] :as expr} expected {is-loop :loop? :keys [expected-bnds]} {::check/keys [check-expr] :as opts}]
@@ -102,7 +119,8 @@
                                                               (some-> expected-bnd r/ret))
                                                        (var-env/with-lexical-env opts env))
                      expected-bnd (when is-loop
-                                    (or expected-bnd (-> cexpr u/expr-type r/ret-t)))
+                                    (or expected-bnd
+                                        (widen-loop-binding-init (-> cexpr u/expr-type r/ret-t) opts)))
                      new-env (update-env env sym (if is-loop (r/ret expected-bnd) (u/expr-type cexpr)) is-reachable opts)
                      maybe-reduced (if @is-reachable identity reduced)]
                  (maybe-reduced

--- a/typed/clj.checker/src/typed/cljc/checker/check/nth.clj
+++ b/typed/clj.checker/src/typed/cljc/checker/check/nth.clj
@@ -207,6 +207,29 @@
                               expected
                               opts))))
 
+        ; literal index, but the target type cannot be passed to nth at all
+        ; (it is not Indexed / SequentialSeqable / nil). Without this guard the
+        ; polymorphic nth-function-type application in the next branch fails to
+        ; find a matching arity and throws an internal "No bounds for" error
+        ; (e.g. (nth #{1 2} 0 nil)). Emit a clean delayed type error instead.
+        ; This also covers destructuring of a non-indexable value, which expands
+        ; to (nth target idx nil); when a ::destructure-blame-form rides on the
+        ; target it is used to blame the original destructuring syntax.
+        (and (nat-value? num-t)
+             (not (every? #(valid-first-arg-for-3-arity-nth? % opts) types)))
+        (let [blame (some-> te :form meta :clojure.core.typed.internal/destructure-blame-form)]
+          (err/tc-delayed-error
+            (str "Cannot use nth to index a value of type `"
+                 (prs/unparse-type (expr->type te) opts)
+                 "` (expected an Indexed, SequentialSeqable, or nil value)")
+            (cond-> {:return (assoc expr
+                                    u/expr-type (below/maybe-check-below
+                                                  (r/ret (or default-t r/-any))
+                                                  expected
+                                                  opts))}
+              blame (assoc :blame-form blame))
+            opts))
+
         ; rewrite nth type to be more useful when we have an exact (and interesting) index.
         (nat-value? num-t)
         (let [ft (nth-function-type (-> num-t :val) opts)

--- a/typed/clj.checker/src/typed/cljc/checker/check/unanalyzed.cljc
+++ b/typed/clj.checker/src/typed/cljc/checker/check/unanalyzed.cljc
@@ -43,8 +43,19 @@
     ;(prn `-unanalyzed-special-dispatch form res)
     res))
 
-(defn run-passes+propagate-expr-type [expr opts]
-  (-> expr
+(defn run-passes+propagate-expr-type [expr orig-expr opts]
+  (-> (cond-> expr
+        ;; A defuspecial rule may hand back an already-analyzed node. That skips
+        ;; the :unanalyzed->analyzed transition where `propagate-top-level` marks
+        ;; top-level forms for Gilardi evaluation, so without this an analyzed
+        ;; top-level result would never be evaluated — violating the documented
+        ;; "implicitly evaluated after control returns" contract (e.g. a rule that
+        ;; returns a checked `(let [v (def f)] ...)` would not define `f`).
+        ;; Re-establish the mark from the original (top-level?) expr.
+        (and (ana2/top-level? orig-expr)
+             (not= :unanalyzed (:op expr))
+             (not (ana2/eval-top-level? expr)))
+        ana2/mark-eval-top-level)
       (ana2/run-passes opts)
       (into (select-keys expr [u/expr-type]))))
 
@@ -112,12 +123,17 @@
         [argv args] (if (vector? (first args))
                       ((juxt first rest) args)
                       [nil args])
-        gopts (gensym 'opts)]
+        gopts (gensym 'opts)
+        gexpr (gensym 'expr)]
     (assert (vector? argv))
     (assert (not-any? #{'&} argv))
     (assert (= 3 (count argv)))
     `(defn ~vsym
        ~@(when doc [doc])
-       ~(-> argv pop (conj gopts))
-       (some-> (let [~(peek argv) ~gopts] ~@args)
-               (run-passes+propagate-expr-type ~gopts)))))
+       [~gexpr ~(nth argv 1) ~gopts]
+       (some-> (let [~(nth argv 0) ~gexpr
+                     ~(nth argv 2) ~gopts]
+                 ~@args)
+               ;; pass the original (pre-rule) expr so the wrapper can recover its
+               ;; top-level status for Gilardi evaluation (see run-passes+…).
+               (run-passes+propagate-expr-type ~gexpr ~gopts)))))

--- a/typed/clj.checker/test/typed_test/cljc/checker/check/let.clj
+++ b/typed/clj.checker/test/typed_test/cljc/checker/check/let.clj
@@ -5,6 +5,9 @@
 (deftest core-loop-unannotated-test
   (is-tc-e #(cc/loop [a 1] (t/ann-form a Long)))
   (is-tc-err #(cc/loop [a 1] (recur (t/ann-form 1 t/Int))))
-  ;; TODO generalize init type
-  (do (is-tc-err #(cc/loop [a 1] (recur 2)))
-      (is-tc-e #(cc/loop [a 1] (t/ann-form a '1)))))
+  ;; An unannotated loop binding's init type is generalized to the class of the
+  ;; literal (here Long), so the loop invariant accepts every iteration: (recur 2)
+  ;; now checks, and the binding is no longer the singleton (Val 1).
+  (do (is-tc-e #(cc/loop [a 1] (recur 2)))
+      (is-tc-err #(cc/loop [a 1] (t/ann-form a '1)))
+      (is-tc-e #(cc/loop [a 1] (t/ann-form a Long)))))

--- a/typed/lib.clojure/src/typed/clj/ext/clojure/core__let.clj
+++ b/typed/lib.clojure/src/typed/clj/ext/clojure/core__let.clj
@@ -342,9 +342,41 @@
               (-> (pad-vector expanded-bindings bvec)
                   (with-meta (meta bvec)))))))
 
+(defn- check-let-via-let*
+  "Expand a clojure.core/let one layer to a let* and check it normally
+  (analyze-outer + check-expr), the way core/fn and core/defn handle their
+  bodies. The result is a fully-checked :let node, so each binding's inferred
+  type lands on its binding AST node exactly like let*/loop* already expose them
+  (check/let.clj) — including the leaf bindings produced by a destructuring
+  pattern, which clojure.core/let expands to simple-symbol let* binders. Inner
+  top-level defs (defmulti/defrecord expansions that nest a let) are still
+  evaluated thanks to the defuspecial implicit-eval fix for analyzed results."
+  [expr expected {::check/keys [check-expr] :as opts}]
+  (-> expr
+      (ana2/analyze-outer opts)
+      (check-expr expected opts)))
+
 (defuspecial defuspecial__let
-  "defuspecial implementation for clojure.core/let"
-  [{ana-env :env :keys [form] :as expr} expected {::check/keys [check-expr] :as opts}]
+  "defuspecial implementation for clojure.core/let.
+
+  Goal: expose each binding's inferred type on the checked :let AST node (like
+  let*/loop*), including the leaf bindings of a destructuring pattern, so tools
+  consuming the AST can read per-binding types.
+
+  No destructuring: expand to let* and check normally (check-let-via-let*) — the
+  checked :let node carries per-binding types directly.
+
+  Destructuring: first run the bespoke destructure-aware check
+  (check-let-bindings), which produces TypedClojure's friendly destructure type
+  errors (a raw nth-based macroexpansion would only give a generic nth error).
+  If that pass is clean and reachable, re-check via check-let-via-let* so the
+  per-binding types land on the AST; the clean re-check adds no new errors. If it
+  is not clean (a destructure type error) or unreachable, keep the bespoke result
+  so the friendly error is the one surfaced.
+
+  check-let-bindings / update-destructure-env remain for core/for, which drives
+  them directly."
+  [{ana-env :env :keys [form] :as expr} expected {::check/keys [check-expr] ::vs/keys [type-errors] :as opts}]
   (assert check-expr)
   (let [_ (assert (next form)
                   (str "Expected 1 or more arguments to clojure.core/let: " form))
@@ -352,31 +384,41 @@
         _ (assert (vector? bvec)
                   (str "Expected binding vector as first argument of clojure.core/let:" (pr-str bvec)))
         _ (assert (even? (count bvec))
-                  (str "Uneven binding vector passed to clojure.core/let: " bvec))
-        {:keys [prop-env ana-env expanded-bindings new-syms reachable]}
-        (check-let-bindings
-          {:new-syms #{}
-           :prop-env (lex/lexical-env opts)
-           :ana-env ana-env}
-          bvec
-          opts)]
-    (cond
-      (not reachable) (assoc expr 
-                             :form (-> (list* (first form)
-                                              expanded-bindings
-                                              body-syns)
-                                       (with-meta (meta form)))
-                             u/expr-type (or expected (r/ret (r/Bottom))))
-      :else (let [cbody (let [body (-> `(do ~@body-syns)
-                                       (ana2/unanalyzed ana-env opts))
-                              opts (var-env/with-lexical-env opts prop-env)]
-                          (let [opts (assoc opts ::vs/current-expr body)]
-                            (-> body
-                                (check-expr expected opts))))
-                  unshadowed-ret (let/erase-objects new-syms (u/expr-type cbody) opts)]
-              (assoc expr
-                     :form (-> (list (first form)
-                                     expanded-bindings
-                                     (emit-form/emit-form cbody opts))
-                               (with-meta (meta form)))
-                     u/expr-type unshadowed-ret)))))
+                  (str "Uneven binding vector passed to clojure.core/let: " bvec))]
+    (if (every? simple-symbol? (take-nth 2 bvec))
+      ;; No destructuring: nothing bespoke to preserve, check directly.
+      (check-let-via-let* expr expected opts)
+      ;; Destructuring: bespoke pass for friendly errors, then expose types on a
+      ;; clean check.
+      (let [err-before (count (some-> type-errors deref))
+            {:keys [prop-env ana-env expanded-bindings new-syms reachable]}
+            (check-let-bindings
+              {:new-syms #{}
+               :prop-env (lex/lexical-env opts)
+               :ana-env ana-env}
+              bvec
+              opts)
+            clean? (and reachable
+                        (= err-before (count (some-> type-errors deref))))]
+        (if clean?
+          (check-let-via-let* expr expected opts)
+          (cond
+            (not reachable) (assoc expr
+                                   :form (-> (list* (first form)
+                                                    expanded-bindings
+                                                    body-syns)
+                                             (with-meta (meta form)))
+                                   u/expr-type (or expected (r/ret (r/Bottom))))
+            :else (let [cbody (let [body (-> `(do ~@body-syns)
+                                             (ana2/unanalyzed ana-env opts))
+                                    opts (var-env/with-lexical-env opts prop-env)]
+                                (let [opts (assoc opts ::vs/current-expr body)]
+                                  (-> body
+                                      (check-expr expected opts))))
+                        unshadowed-ret (let/erase-objects new-syms (u/expr-type cbody) opts)]
+                    (assoc expr
+                           :form (-> (list (first form)
+                                           expanded-bindings
+                                           (emit-form/emit-form cbody opts))
+                                     (with-meta (meta form)))
+                           u/expr-type unshadowed-ret))))))))

--- a/typed/lib.clojure/test/typed_test/clj/ext/clojure/core__let.clj
+++ b/typed/lib.clojure/test/typed_test/clj/ext/clojure/core__let.clj
@@ -204,3 +204,37 @@
                (let [v (.hasRoot v)]
                  v)
                nil))))
+
+(defn- binding-types-on-ast
+  "Map of {binding-sym → its checked TCResult type} read off every :let binding
+  node of the checked AST for `form`."
+  [form]
+  (let [etk :typed.cljc.checker.utils/expr-type
+        ast (:checked-ast (t/check-form-info form :checked-ast true))
+        acc (atom {})]
+    (letfn [(walk [n]
+              (when (map? n)
+                (when (= :let (:op n))
+                  (doseq [b (:bindings n)]
+                    (when-let [tcr (get b etk)]
+                      (swap! acc assoc (:form b) (:t tcr)))))
+                (doseq [k (:children n)]
+                  (let [v (get n k)] (if (vector? v) (run! walk v) (walk v))))))]
+      (walk ast))
+    @acc))
+
+(deftest let-binding-types-on-ast-test
+  ;; Per-binding types are exposed on the checked let AST node's :bindings,
+  ;; like let*/loop* — so tools consuming the AST can read each binding's
+  ;; inferred type (e.g. to drive downstream code generation).
+  (let [acc (binding-types-on-ast '(let [x 1 y "a"] y))]
+    (is (contains? acc 'x) "binding x's type is on the checked AST")
+    (is (contains? acc 'y) "binding y's type is on the checked AST")))
+
+(deftest let-destructuring-binding-types-on-ast-test
+  ;; The leaf bindings of a destructuring pattern also expose their inferred
+  ;; type on the checked AST (the pattern is expanded to simple-symbol let*
+  ;; binders, each carrying u/expr-type).
+  (let [acc (binding-types-on-ast '(let [[a b] [1 "a"]] b))]
+    (is (contains? acc 'a) "destructured leaf binding a's type is on the checked AST")
+    (is (contains? acc 'b) "destructured leaf binding b's type is on the checked AST")))


### PR DESCRIPTION
## Goal

Expose each `let` binding's inferred type on the checked `:let` AST node — like `let*`/`loop*` already do — **including the leaf bindings of a destructuring pattern**, so tools that consume the checked AST (in my case a JIT that reads per-binding types to devirtualize arithmetic) can read them. Along the way this fixes a latent `nth` internal-error bug and generalizes unannotated `loop` binding inference.

This is the follow-up to our Slack discussion about per-binding `let` types and the destructuring case. It supersedes the earlier `core/let` work and is intended as a basis for discussion as much as a merge candidate — happy to split it into separate PRs (see "Separability" below).

## Commits

1. **`defuspecial`: evaluate analyzed top-level results (honor implicit-eval contract).**
   `install-defuspecial` documents that a rule's returned expression "is implicitly evaluated after control returns." That holds when a rule returns the original `:unanalyzed` node (the `:unanalyzed`→analyzed transition runs `propagate-top-level`, marking `::eval-gilardi?`). A rule that returns an **already-analyzed** node skips that transition, so a top-level analyzed result was never evaluated — e.g. a rule returning a checked `(let [v (def f)] …)` would type-check but never define `f`. `run-passes+propagate-expr-type` now re-establishes the mark from the original expr's top-level status. Gated on `(not= :unanalyzed (:op expr))`, so it's a no-op for every existing re-emit rule.

2. **`check/nth`: clean delayed error for nth on a non-indexable target.**
   `(nth x i default)` with a literal index and a target that is not `Indexed`/`SequentialSeqable`/`nil` (e.g. `(nth #{1 2} 0 nil)`) fell into `invoke-nth`'s polymorphic `nth-function-type` application, which finds no matching arity and throws an internal **"No bounds for y…"** error. Guard with the existing `valid-first-arg-for-3-arity-nth?` predicate and emit a clean delayed type error instead. The error is blame-form aware, so for a destructuring expansion (which lowers to `(nth target idx nil)`) it blames the original destructuring syntax. This is a standalone bug fix.

3. **`core/let`: expose per-binding types on the checked AST, incl. destructuring.**
   The rule re-emitted an `:unanalyzed` form, so its per-binding types were lost when `run-passes` re-analyzed it. Now:
   - **No destructuring** → expand to `let*` and check normally (`check-let-via-let*`, the way `core/fn`/`core/defn` already handle their bodies). The checked `:let` node carries per-binding types directly.
   - **Destructuring** → run the bespoke destructure-aware check first (it produces TC's friendly destructure type errors); if that pass is clean and reachable, re-check via `check-let-via-let*` so per-binding types land on the AST; otherwise keep the bespoke result so the friendly error is surfaced. `check-let-bindings`/`update-destructure-env` remain for `core/for`, which drives them directly.

   Why not just `analyze-outer` for the destructuring case too (a true single path with `fn`/`defn`)? Because `clojure.core/destructure` builds **fresh** `nth`/`get` forms and drops the sub-pattern metadata, so the friendly `"cannot be destructured via syntax [a]"` message can't be reconstructed at the `nth` site. Keeping the bespoke walk for error production preserves the messages exactly.

4. **`check/let`: widen unannotated loop binding init types to their class.**
   #249 lets an unannotated `loop` infer each binding's type from its init, but keeps the singleton `Value` type (`(Val 0)` from the literal `0`). That's too narrow to be a loop invariant: `(loop [i 0] (recur (inc i)))` is rejected because `(Val 1) </: (Val 0)`. The #249 test even left a `;; TODO generalize init type`. This widens a `Value`-typed init to the **concrete class** of its value (`Long` for `0`, `Double` for `0.0`) — so the common accumulator loop checks while keeping the primitive class. Only unannotated loop bindings are affected (annotated loops and plain `let`/`let*` are gated out). Updates `core-loop-unannotated-test` to the generalized behavior.

## Tests

- `clj.checker`: 454 tests / 2054 assertions, **0 failures** (incl. `nth-path-elem-test`, `loop-errors-test`, the updated `core-loop-unannotated-test`, and the defrecord/defmulti-heavy `clojure.core.typed.test.core`).
- `lib.clojure`: `core` (holds the fn/defn/defmethod `vector-destructure-error-msg-test` and defrecord/defmulti eval tests), `core__let`, `core__fn`, `core__for`, `core__doseq` — **0 failures**. New tests assert destructured leaf bindings (`a`, `b`) and plain bindings expose types on the checked AST.

## Known follow-up (not in this PR)

The destructuring path type-checks the bindings twice on the clean path (bespoke validate pass + typed re-check). It's eval-safe (confirmed by `defmulti-expansion-test`) but redundant. The single-check version is what you described in Slack — have the bespoke walk *build* the annotated `let*` node from the `cexpr`s it already computes, instead of discarding them and re-checking. I left it as a follow-up because it means hand-constructing `:binding`/`:let` AST nodes (satisfying the env/atom/children/uniquify invariants the downstream passes rely on) inside code shared with `core/for` — I'd rather get your read on the node-construction approach first.

## Separability

These are largely independent and can be split if you prefer:
- #2 (`nth`) and #4 (`loop`) are standalone bug fix / feature.
- #1 (`defuspecial`) is a prerequisite for #3 (`core/let`).

Let me know how you'd like it carved up.
