### PR TITLE
Model Valhalla value classes as non-nullable

### DIFF
--- a/typed/clj.checker/src/typed/cljc/checker/check/utils.cljc
+++ b/typed/clj.checker/src/typed/cljc/checker/check/utils.cljc
@@ -182,6 +182,17 @@
 (declare symbol->PArray)
 
 ;[t/Sym Boolean -> Type]
+(defn- value-class?
+  "True if Class c is a Valhalla value class. Value-typed fields and value-class
+  array elements are non-nullable, so they must not widen to (U X nil) — otherwise
+  field-access chains through them (e.g. (.-field (aget value-class-array i)))
+  fail host-interop resolution and never type-check. Reflective so it no-ops on
+  identity-only (non-Valhalla) JDKs where the predicate is simply always false."
+  [c]
+  (and (class? c)
+       (try (boolean (clojure.lang.Reflector/invokeInstanceMethod c "isValue" (object-array 0)))
+            (catch Throwable _ false))))
+
 (defn Java-symbol->Type [sym nilable? opts]
   {:pre [(symbol? sym)
          (boolean? nilable?)]
@@ -190,7 +201,8 @@
       (symbol->PArray sym nilable? opts)
       (when-let [cls (resolve sym)]
         (c/Un (cons (c/RClass-of-with-unknown-params cls opts)
-                    (when nilable?
+                    ;; Valhalla value classes are non-nullable.
+                    (when (and nilable? (not (value-class? cls)))
                       [r/-nil]))
               opts))
       (err/tc-delayed-error (str "Method or field symbol " sym " does not resolve to a type") opts)))


### PR DESCRIPTION
## Problem

`Java-symbol->Type` widens a reference field / array-element type to `(U X nil)`. This is sound for ordinary identity classes — a Java reference can be `null` — but it is **incorrect for Valhalla value classes**: a value-typed field always holds a value (its default is the all-zero instance), and value-class array elements are non-nullable. The JVM physically forbids storing `null` into either.

Modeling them as `(U X nil)` therefore admits a `null` the JVM cannot produce. A concrete consequence: host-interop chains through a value-class array element — e.g. `(.-field (aget value-class-array i))` — fail to resolve because the receiver is seen as possibly-`nil`.

## Fix

In `Java-symbol->Type`, suppress the `nil` widening when the resolved class is a Valhalla value class, so a value-typed field / array element is typed as `X` rather than `(U X nil)`.

Value classes are detected with `Class.isValue()`, called **reflectively** and guarded so it returns `false` on identity-only (non-Valhalla) JDKs — where there are no value classes, so the change is a strict no-op.

## Scope

Single function, ~13 lines. No behavior change on non-Valhalla JDKs.