### PR TITLE
Resolve host-interop on non-:local receivers via TC-inferred type

### DIFF
--- a/typed/clj.checker/src/typed/clj/checker/check/host_interop.cljc
+++ b/typed/clj.checker/src/typed/clj/checker/check/host_interop.cljc
@@ -37,17 +37,17 @@
     (symbol (#?(:cljr Type/.FullName :default Class/.getName) class))))
 
 (defn add-type-hints
-  "Add type hints to an expression, only if it can
-  be preserved via emit-form to the Clojure compiler.
-
-  The most reliable AST node to convey a type hint
-  is :local, so we restrict adding type hints to only
-  :local nodes."
+  "Stamp a host-interop receiver's analyzer :tag / :o-tag from its TC-inferred
+  type, so subsequent host-interop resolution (analyze-host-expr, which keys off
+  :tag/:o-tag) can resolve it. Previously restricted to :local nodes; lifting the
+  restriction lets an inline receiver whose analyzer :tag is Object but whose
+  TC expr-type is a concrete class — e.g. (aget value-class-array i) typed as the
+  element class — resolve a following .-field access without first let-binding it.
+  Guarded by (obj? f) so only IObj forms receive the :tag form-metadata."
   [expr]
   (let [{:keys [t]} (u/expr-type expr)
         cls (cu/Type->Class t)]
-    (if (and cls
-             (= :local (:op expr)))
+    (if cls
       (-> expr
           (assoc :o-tag cls
                  :tag cls)


### PR DESCRIPTION
## Problem

`add-type-hints` bridges a host-interop receiver's TC-inferred type onto its analyzer `:tag` / `:o-tag`, which `analyze-host-expr` keys off to resolve the interop into an `:instance-field` / `:instance-call`. It is currently restricted to `:local` nodes (a conservatism noted in the docstring about the hint surviving `emit-form` back to the Clojure compiler).

As a result, an **inline** receiver whose analyzer `:tag` is `Object` but whose TC `expr-type` is a concrete class does not resolve a following `.-field` / method access. The motivating case: `(.-field (aget value-class-array i))` — `aget` is typed `Object` by the analyzer, but TC's `expr-type` knows the element class — so the field access is reported as "Unresolved host interop" unless the receiver is first `let`-bound (making it a `:local`).

## Fix

Lift the `:local` restriction: stamp `:tag` / `:o-tag` from `expr-type` on any node whose `Type->Class` yields a class. Resolution during checking only needs the in-memory `:tag`, which `analyze-host-expr` reads regardless of the node's `:op`. The `:tag` form-metadata write stays guarded by `(obj? f)`, so only `IObj` forms are touched.

This lets inline receivers resolve without an intermediate binding.

## Notes / discussion

- The original `:local` restriction was emit-form conservatism rather than a correctness requirement for resolution. If maintainers prefer a narrower change, this could be scoped to specific node ops (e.g. `:static-call`/`:invoke`) or gated on the inferred type being a concrete (non-`Object`) class. Happy to adjust.
- Pairs naturally with #254 (value classes non-nullable), which is what makes the `aget`-element case yield a concrete class for this to stamp.