### PR TITLE
expand let to let* without destructuring, add tc-ast

### DIFF
--- a/typed/clj.checker/src/typed/clj/checker/test_utils.cljc
+++ b/typed/clj.checker/src/typed/clj/checker/test_utils.cljc
@@ -34,7 +34,9 @@
        (run! remove-ns @*remove-nsyms*)
        res#)))
 
-(defn tc-common* [frm {{:keys [syn provided?]} :expected-syntax :keys [expected-ret requires ns-meta check-config] :as opt}]
+(defn tc-common* [frm {{:keys [syn provided?]} :expected-syntax
+                       :keys [expected-ret requires ns-meta check-config checked-ast]
+                       :as opt}]
   (check-opt opt)
   (let [file *file*
         nsym (gensym 'clojure.core.typed.test.temp)
@@ -64,7 +66,8 @@
                       :expected-ret expected-ret#
                       :expected '~syn
                       :type-provided? ~provided?
-                      :check-config check-config#)]
+                      :check-config check-config#
+                      :checked-ast ~(boolean checked-ast))]
            (or (some-> *remove-nsyms* (swap! conj '~nsym))
                (remove-ns '~nsym))
            res#)))))
@@ -239,6 +242,12 @@
        (throw ex#)
        ret#)))
 
+(defmacro tc-ast [form]
+  `(let [{ex# :ex checked-ast# :checked-ast} ~(tc-common* form {:checked-ast true})]
+     (if ex#
+       (throw ex#)
+       checked-ast#)))
+
 (defmacro tc [form]
   `(t/check-form* '~form))
 
@@ -249,7 +258,7 @@
   [& body]
   `(let [s# (java.io.StringWriter.)]
      (binding [*err* s#]
-       ~@body
+       (do ~@body)
        (str s#))))
 
 ;; from clojure.test-helper
@@ -260,7 +269,7 @@
   `(let [s# (java.io.StringWriter.)
          p# (java.io.PrintWriter. s#)]
      (binding [*err* p#]
-       ~@body
+       (do ~@body)
        (str s#))))
 
 ;; from clojure.test-helper

--- a/typed/lib.clojure/src/typed/clj/ext/clojure/core__let.clj
+++ b/typed/lib.clojure/src/typed/clj/ext/clojure/core__let.clj
@@ -342,17 +342,9 @@
               (-> (pad-vector expanded-bindings bvec)
                   (with-meta (meta bvec)))))))
 
-(defuspecial defuspecial__let
-  "defuspecial implementation for clojure.core/let"
+(defn check-destructured-let
   [{ana-env :env :keys [form] :as expr} expected {::check/keys [check-expr] :as opts}]
-  (assert check-expr)
-  (let [_ (assert (next form)
-                  (str "Expected 1 or more arguments to clojure.core/let: " form))
-        [bvec & body-syns] (next form)
-        _ (assert (vector? bvec)
-                  (str "Expected binding vector as first argument of clojure.core/let:" (pr-str bvec)))
-        _ (assert (even? (count bvec))
-                  (str "Uneven binding vector passed to clojure.core/let: " bvec))
+  (let [[bvec & body-syns] (next form)
         {:keys [prop-env ana-env expanded-bindings new-syms reachable]}
         (check-let-bindings
           {:new-syms #{}
@@ -380,3 +372,22 @@
                                      (emit-form/emit-form cbody opts))
                                (with-meta (meta form)))
                      u/expr-type unshadowed-ret)))))
+
+(defuspecial defuspecial__let
+  "defuspecial implementation for clojure.core/let"
+  [{ana-env :env :keys [form] :as expr} expected {::check/keys [check-expr] :as opts}]
+  (let [_ (assert (next form)
+                  (str "Expected 1 or more arguments to clojure.core/let: " form))
+        [bvec & body-syns] (next form)
+        _ (assert (vector? bvec)
+                  (str "Expected binding vector as first argument of clojure.core/let:" (pr-str bvec)))
+        _ (assert (even? (count bvec))
+                  (str "Uneven binding vector passed to clojure.core/let: " bvec))
+        destructured? (not-every? #(symbol? (nth bvec %))
+                                  (range 0 (/ (count bvec) 2) 2))]
+    (if destructured?
+      ;; TODO always expand into let*, ideally in a single pass plus enhanced error messages
+      (check-destructured-let expr expected opts)
+      (-> expr
+          (ana2/analyze-outer opts)
+          (check-expr expected opts)))))

--- a/typed/lib.clojure/test/typed_test/clj/ext/clojure/core__let.clj
+++ b/typed/lib.clojure/test/typed_test/clj/ext/clojure/core__let.clj
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.core.typed :as t]
             [typed.clj.checker.parse-unparse :as prs]
-            [typed.clj.checker.test-utils :refer :all]))
+            [typed.clj.checker.test-utils :refer :all]
+            [typed.cljc.checker.type-rep :as r]
+            [typed.cljc.checker.utils :as u]))
 
 (deftest let-test
   (is-tc-e (let [a 1] a) t/Int)
@@ -204,3 +206,21 @@
                (let [v (.hasRoot v)]
                  v)
                nil))))
+
+(deftest let-to-let*-test
+  (testing "no destructuring"
+    (let [ast (tc-ast (let [a 1 b 2] a))]
+      (is (= :let (:op ast)))
+      (is (= [(r/-val 1) (r/-val 2)]
+             (mapv (comp :t u/expr-type) (:bindings ast))))
+      (is (= :local (-> ast :body :ret :op)))
+      (is (= (r/-val 1) (-> ast :body :ret u/expr-type :t)))))
+  (testing "destructured"
+    (let [ast (tc-ast (let [{:keys [a]} {:a 1}] a))]
+      (is (= :let (:op ast)))
+      ;;FIXME missing types
+      (is (= [nil nil nil]
+             (mapv (comp :t u/expr-type) (:bindings ast))))
+      (is (= :local (-> ast :body :ret :ret :op)))
+      ;;FIXME missing type
+      (is (= nil (-> ast :body :ret :ret u/expr-type :t))))))


### PR DESCRIPTION
Related https://github.com/typedclojure/typedclojure/pull/253/changes

Adds type information to `let` forms that have no destructuring.