### PR TITLE
despecialize nth on invalid first arg

### DIFF
--- a/typed/clj.checker/src/typed/cljc/checker/check/nth.clj
+++ b/typed/clj.checker/src/typed/cljc/checker/check/nth.clj
@@ -185,14 +185,16 @@
                                                   (update :args #(mapv (fn [e] (check-expr e nil opts)) %)))
                                         (#{:host-call} (:op expr))
                                         (update :target check-expr nil opts))
-          types (let [ts (c/fully-resolve-type (expr->type te) opts)]
-                  (if (r/Union? ts)
-                    (:types ts)
-                    [ts]))
+          target-t (c/fully-resolve-type (expr->type te) opts)
+          types (if (r/Union? target-t)
+                  (:types target-t)
+                  [target-t])
           num-t (expr->type ne)
           default-t (expr->type de)]
       ;(prn "nth" types)
       (cond
+        (not (valid-first-arg-for-3-arity-nth? target-t opts)) nil
+
         (and (nat-value? num-t)
              (let [super (c/Un [r/-nil r/-any-hsequential] opts)]
                (every? #(ind/subtype? % super opts)

--- a/typed/clj.checker/test/typed_test/cljc/checker/check/nth.clj
+++ b/typed/clj.checker/test/typed_test/cljc/checker/check/nth.clj
@@ -1,0 +1,10 @@
+(ns ^:typed.clojure ^:no-doc typed-test.cljc.checker.check.nth
+  (:require [clojure.test :refer [deftest is testing]]
+            [typed.clj.checker.test-utils :refer :all]))
+
+(deftest despecialize-on-invalid-first-arg-test
+  (is (= :typed.clojure/app-type-error
+         (-> (is-tc-err-messages #(nth #{} 0))
+             :type-errors
+             first
+             :type-error))))


### PR DESCRIPTION
Reimplemented fix from https://github.com/typedclojure/typedclojure/pull/253